### PR TITLE
🔧 (composer type) changes to vendormodule to prevent new directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "evanshunt/serverinfo",
 	"description": "A small SilverStripe module that provides logged in users -that have permission to view this module- assess to phpinfo() print out. This helps in quickly finding server info.",
-	"type": "silverstripe-module",
+	"type": "silverstripe-vendormodule",
 	"homepage": "http://github.com/evanshunt/serverinfo",
 	"keywords": ["silverstripe", "serverinfo"],
 	"license": "BSD-3-Clause",


### PR DESCRIPTION
`silverstripe-vendormodule` is the standard for SS4 which installs in the vendor directory `silverstripe-module` was more commonly used in SS3 where dependencies got installed within the project structure itself